### PR TITLE
BUG: allow connecting category column to primary_key/forerign_key column

### DIFF
--- a/models/autog/action.py
+++ b/models/autog/action.py
@@ -277,7 +277,7 @@ def connect_two_columns(dbb, table_1_name, table_1_col_name, table_2_name, table
     # import ipdb; ipdb.set_trace()
     if type_of_col1 == 'foreign_key' and type_of_col2 == 'foreign_key' and columninfo_dict[f'{table_1_name}.{table_1_col_name}'].link_to == columninfo_dict[f'{table_2_name}.{table_2_col_name}'].link_to:
         return dbb
-    if type_of_col1 != type_of_col2:
+    if type_of_col1 != type_of_col2 and type_of_col2 not in ['primary_key', 'foreign_key']:
         return dbb 
     
     ## two non key types with the same type 


### PR DESCRIPTION
**Issue:**

No action was actually taken when connecting `table_1.column_1 (dtype=category)` to `table_2.column_2 (dtype=primary_key/forerign_key)`.  

This happened because of an incorrect early filter that required `type_of_col1 == type_of_col2`.  

The fix removes this overly strict check, enabling to add FK-PK connections between category and primary_key/forerign_key columns.